### PR TITLE
Scale down puma server

### DIFF
--- a/config/puma.rb
+++ b/config/puma.rb
@@ -4,7 +4,7 @@
 # the maximum value specified for Puma. Default is set to 5 threads for minimum
 # and maximum; this matches the default thread size of Active Record.
 #
-max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 5)
+max_threads_count = ENV.fetch("RAILS_MAX_THREADS", 3)
 min_threads_count = ENV.fetch("RAILS_MIN_THREADS") { max_threads_count }
 threads min_threads_count, max_threads_count
 
@@ -33,7 +33,7 @@ if ENV.fetch("RAILS_ENV", "development") == "production"
   # the concurrency of the application would be max `threads` * `workers`.
   # Workers do not work on JRuby or Windows (both of which do not support
   # processes).
-  workers ENV.fetch("WEB_CONCURRENCY", 2)
+  workers ENV.fetch("WEB_CONCURRENCY", 1)
   # Use the `preload_app!` method when specifying a `workers` number.
   # This directive tells Puma to first boot the application and load code
   # before forking the application. This takes advantage of Copy On Write


### PR DESCRIPTION
So it needs less resources on fly.io for now.